### PR TITLE
fix: support git worktree by enabling DotGitCommonDir

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -20,9 +20,9 @@ const (
 
 // getCurrentGitDirectoryFunc is a variable that can be replaced for testing
 var getCurrentGitDirectoryFunc = func() (*git.Repository, error) {
-	// Open the Git repository in the current working directory or any parent directory
 	repo, err := git.PlainOpenWithOptions(".", &git.PlainOpenOptions{
-		DetectDotGit: true,
+		DetectDotGit:        true,
+		EnableDotGitCommonDir: true,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/git_test.go
+++ b/cmd/git_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func Test_getCurrentGitDirectory(t *testing.T) {
-	// Use setupTestRepo for setup
 	_, cleanup := testhelper.SetupTestRepo(t, "https://github.com/zhaochunqi/git-open.git", "main")
 	defer cleanup()
 
@@ -56,6 +55,59 @@ func Test_getCurrentGitDirectory(t *testing.T) {
 				t.Error("getCurrentGitDirectory() = nil, want valid repository")
 			}
 		})
+	}
+}
+
+func Test_getCurrentGitDirectory_Worktree(t *testing.T) {
+	_, cleanup := testhelper.SetupTestWorktree(t, "https://github.com/zhaochunqi/git-open.git", "feature-branch")
+	defer cleanup()
+
+	repo, err := getCurrentGitDirectory()
+	if err != nil {
+		t.Fatalf("getCurrentGitDirectory() error in worktree = %v", err)
+	}
+	if repo == nil {
+		t.Error("getCurrentGitDirectory() = nil, want valid repository")
+	}
+}
+
+func Test_getRemoteURL_Worktree(t *testing.T) {
+	_, cleanup := testhelper.SetupTestWorktree(t, "https://github.com/zhaochunqi/git-open.git", "feature-branch")
+	defer cleanup()
+
+	repo, err := getCurrentGitDirectory()
+	if err != nil {
+		t.Fatalf("getCurrentGitDirectory() error = %v", err)
+	}
+
+	got, err := getRemoteURL(repo)
+	if err != nil {
+		t.Errorf("getRemoteURL() error = %v", err)
+		return
+	}
+	expectedURL := "https://github.com/zhaochunqi/git-open.git"
+	if got != expectedURL {
+		t.Errorf("getRemoteURL() = %v, want %v", got, expectedURL)
+	}
+}
+
+func Test_getBranchName_Worktree(t *testing.T) {
+	_, cleanup := testhelper.SetupTestWorktree(t, "https://github.com/zhaochunqi/git-open.git", "feature-branch")
+	defer cleanup()
+
+	repo, err := getCurrentGitDirectory()
+	if err != nil {
+		t.Fatalf("getCurrentGitDirectory() error = %v", err)
+	}
+
+	got, err := getBranchName(repo)
+	if err != nil {
+		t.Errorf("getBranchName() error = %v", err)
+		return
+	}
+	expectedBranch := "feature-branch"
+	if got != expectedBranch {
+		t.Errorf("getBranchName() = %v, want %v", got, expectedBranch)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `EnableDotGitCommonDir: true` option to `git.PlainOpenWithOptions` to properly support git worktrees
- Add `SetupTestWorktree` helper function in testhelper for worktree testing
- Add 3 test cases for worktree support: `Test_getCurrentGitDirectory_Worktree`, `Test_getRemoteURL_Worktree`, `Test_getBranchName_Worktree`

## Problem
When using `git open` in a worktree directory, it failed with:
```
Error: error getting git directory: repository does not exist
```

## Solution
Git worktrees use the `commondir` mechanism to share the main repository's objects while maintaining separate HEAD, index, and other per-worktree files. The go-git library requires `EnableDotGitCommonDir` option to properly handle this.

Fixes #37