### PR TITLE
Handle detached HEAD and invalid remote URL; add tests to improve coverage

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -81,7 +82,10 @@ func convertToWebURL(url string) string {
 var getBranchNameFunc = func(repo *git.Repository) (string, error) {
 	head, err := repo.Head()
 	if err == nil {
-		return head.Name().Short(), nil
+		if head.Name().IsBranch() {
+			return head.Name().Short(), nil
+		}
+		err = errors.New("detached HEAD")
 	}
 
 	ref, refErr := repo.Reference("HEAD", true)

--- a/cmd/git_additional_test.go
+++ b/cmd/git_additional_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/zhaochunqi/git-open/internal/testhelper"
+)
+
+func Test_getBranchName_DetachedHEAD(t *testing.T) {
+	_, cleanup := testhelper.SetupTestRepo(t, "https://github.com/test/repo.git", "main")
+	defer cleanup()
+
+	repo, err := getCurrentGitDirectory()
+	if err != nil {
+		t.Fatalf("getCurrentGitDirectory() error = %v", err)
+	}
+
+	head, err := repo.Head()
+	if err != nil {
+		t.Fatalf("repo.Head() error = %v", err)
+	}
+
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.HEAD, head.Hash())); err != nil {
+		t.Fatalf("set detached HEAD failed: %v", err)
+	}
+
+	branch, err := getBranchName(repo)
+	if err == nil {
+		t.Fatalf("getBranchName() expected error on detached HEAD, got branch=%q", branch)
+	}
+	if !strings.Contains(err.Error(), "error getting HEAD") {
+		t.Fatalf("getBranchName() error = %v, want message containing 'error getting HEAD'", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,6 +38,9 @@ and converts it to a web URL. The web URL is then printed to the console.`,
 
 		// Convert the remote URL to a web URL
 		webURL := convertToWebURL(remoteURL)
+		if webURL == "" {
+			return fmt.Errorf("unsupported remote URL format: %s", remoteURL)
+		}
 
 		// Open the web URL in the browser if the -o flag is provided
 		plain, _ := cmd.Flags().GetBool("plain")

--- a/cmd/root_additional_test.go
+++ b/cmd/root_additional_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/spf13/cobra"
+	"github.com/zhaochunqi/git-open/internal/testhelper"
+)
+
+func Test_rootCmd_InvalidRemoteURLFormat(t *testing.T) {
+	originalGetRemoteURLFunc := getRemoteURLFunc
+	defer func() { getRemoteURLFunc = originalGetRemoteURLFunc }()
+
+	_, cleanup := testhelper.SetupTestRepo(t, "https://github.com/test/repo.git", "main")
+	defer cleanup()
+
+	getRemoteURLFunc = func(repo *git.Repository) (string, error) {
+		return "invalid-remote", nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.Flags().Bool("plain", false, "")
+	cmd.Flags().Bool("version", false, "")
+
+	err := rootCmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Fatal("rootCmd.RunE() expected error for invalid remote URL format, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported remote URL format") {
+		t.Fatalf("rootCmd.RunE() error = %v, want message containing 'unsupported remote URL format'", err)
+	}
+}


### PR DESCRIPTION
### Motivation

- Avoid producing incorrect branch URLs when the repository is in a detached HEAD state by treating non-branch `HEAD` as an error instead of returning `HEAD` as a branch name.  
- Prevent attempting to open an empty/invalid web URL by validating the result of `convertToWebURL` early.  
- Improve unit test coverage for these edge cases so behavior is well-specified and regressions are caught.

### Description

- Hardened branch resolution in `getBranchName` (in `cmd/git.go`) to return a clear error when `repo.Head()` points to a non-branch (detached HEAD) and fall back to reference lookup only if necessary.  
- Added validation in `rootCmd.RunE` (in `cmd/root.go`) to return an error when `convertToWebURL(remoteURL)` yields an empty string.  
- Added `cmd/git_additional_test.go` with `Test_getBranchName_DetachedHEAD` to cover the detached-HEAD path for `getBranchName`.  
- Added `cmd/root_additional_test.go` with `Test_rootCmd_InvalidRemoteURLFormat` to assert `rootCmd.RunE` errors on unsupported remote URL formats.

### Testing

- Attempted to run `go test ./... -coverprofile=coverage.out`, but the Go toolchain is not available in this environment (`go: command not found`).  
- Attempted to run `gofmt -w` on modified files, but `gofmt` is not available in this environment (`gofmt: command not found`).  
- New unit tests were added (`cmd/git_additional_test.go`, `cmd/root_additional_test.go`) and exercise the new code paths, but they were not executed here due to the missing Go toolchain.  
- No automated test failures were observed within the repository actions performed locally (formatting and test execution were not possible in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df61d2f9788331a8c2e39aa1cdeb98)