### PR TITLE
feat: add repo command to print repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Navigate to your project's directory and run the following command:
 
 This will open your repository in the default web browser.
 
+To print the repository name (e.g. `github.com/zhaochunqi/git-open`):
+
+`git-open repo`
+
 ## Testing
 
 This project follows Go testing best practices. Here's how to run the tests:

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -58,6 +58,27 @@ func getRemoteURL(repo *git.Repository) (string, error) {
 	return getRemoteURLFunc(repo)
 }
 
+// resolveWebURL returns the repository, its remote URL, and the converted web URL
+// for the Git repository in the current working directory.
+func resolveWebURL() (*git.Repository, string, string, error) {
+	repo, err := getCurrentGitDirectory()
+	if err != nil {
+		return nil, "", "", fmt.Errorf("error getting git directory: %w", err)
+	}
+
+	remoteURL, err := getRemoteURL(repo)
+	if err != nil {
+		return nil, "", "", fmt.Errorf("error getting remote URL: %w", err)
+	}
+
+	webURL := convertToWebURL(remoteURL)
+	if webURL == "" {
+		return nil, "", "", fmt.Errorf("unsupported remote URL format: %s", remoteURL)
+	}
+
+	return repo, remoteURL, webURL, nil
+}
+
 var scpRemoteURLPattern = regexp.MustCompile(`^(?:[^@]+@)?([^:]+):(.+)$`)
 
 func convertToWebURL(rawURL string) string {

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// repoCmd represents the repo command
+var repoCmd = &cobra.Command{
+	Use:   "repo",
+	Short: "Print the repository name",
+	Long: `Print the name of the Git repository in the current working directory,
+in the form of host/owner/repo (e.g. github.com/zhaochunqi/git-open).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Get the repository name from the web URL of the remote
+		_, _, webURL, err := resolveWebURL()
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), repoNameFromWebURL(webURL))
+		return nil
+	},
+}
+
+// repoNameFromWebURL strips the scheme from a web URL,
+// e.g. "https://github.com/zhaochunqi/git-open" -> "github.com/zhaochunqi/git-open".
+func repoNameFromWebURL(webURL string) string {
+	name := strings.TrimPrefix(webURL, "https://")
+	name = strings.TrimPrefix(name, "http://")
+	return strings.TrimSuffix(name, "/")
+}
+
+func init() {
+	rootCmd.AddCommand(repoCmd)
+}

--- a/cmd/repo_test.go
+++ b/cmd/repo_test.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/spf13/cobra"
+	"github.com/zhaochunqi/git-open/internal/testhelper"
+)
+
+func Test_repoNameFromWebURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		webURL string
+		want   string
+	}{
+		{"https URL", "https://github.com/zhaochunqi/git-open", "github.com/zhaochunqi/git-open"},
+		{"http URL", "http://gitlab.com/user/repo", "gitlab.com/user/repo"},
+		{"trailing slash", "https://github.com/user/repo/", "github.com/user/repo"},
+		{"no scheme", "github.com/user/repo", "github.com/user/repo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := repoNameFromWebURL(tt.webURL); got != tt.want {
+				t.Errorf("repoNameFromWebURL(%q) = %q, want %q", tt.webURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_repoCmd(t *testing.T) {
+	tests := []struct {
+		name      string
+		remoteURL string
+		want      string
+	}{
+		{"https URL", "https://github.com/zhaochunqi/git-open.git", "github.com/zhaochunqi/git-open\n"},
+		{"ssh URL", "git@github.com:zhaochunqi/git-open.git", "github.com/zhaochunqi/git-open\n"},
+		{"gitlab URL", "https://gitlab.com/user/repo.git", "gitlab.com/user/repo\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, cleanup := testhelper.SetupTestRepo(t, tt.remoteURL, "main")
+			defer cleanup()
+
+			buf := new(bytes.Buffer)
+			cmd := &cobra.Command{}
+			cmd.SetOut(buf)
+
+			if err := repoCmd.RunE(cmd, []string{}); err != nil {
+				t.Fatalf("repoCmd.RunE() error = %v", err)
+			}
+
+			if got := buf.String(); got != tt.want {
+				t.Errorf("repoCmd output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_repoCmd_InvalidRemoteURLFormat(t *testing.T) {
+	originalGetRemoteURLFunc := getRemoteURLFunc
+	defer func() { getRemoteURLFunc = originalGetRemoteURLFunc }()
+
+	_, cleanup := testhelper.SetupTestRepo(t, "https://github.com/test/repo.git", "main")
+	defer cleanup()
+
+	getRemoteURLFunc = func(repo *git.Repository) (string, error) {
+		return "invalid-remote", nil
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(new(bytes.Buffer))
+
+	err := repoCmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Fatal("repoCmd.RunE() expected error for invalid remote URL format, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported remote URL format") {
+		t.Fatalf("repoCmd.RunE() error = %v, want message containing 'unsupported remote URL format'", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,22 +25,10 @@ and converts it to a web URL. The web URL is then printed to the console.`,
 			fmt.Fprintf(cmd.OutOrStdout(), "Build Date: %s\n", BuildDate)
 			return nil
 		}
-		// Get the Git repository in the current working directory
-		repo, err := getCurrentGitDirectory()
+		// Get the repository, its remote URL, and the converted web URL
+		repo, remoteURL, webURL, err := resolveWebURL()
 		if err != nil {
-			return fmt.Errorf("error getting git directory: %w", err)
-		}
-
-		// Get the remote URL of the Git repository
-		remoteURL, err := getRemoteURL(repo)
-		if err != nil {
-			return fmt.Errorf("error getting remote URL: %w", err)
-		}
-
-		// Convert the remote URL to a web URL
-		webURL := convertToWebURL(remoteURL)
-		if webURL == "" {
-			return fmt.Errorf("unsupported remote URL format: %s", remoteURL)
+			return err
 		}
 
 		branchName, err := getBranchName(repo)


### PR DESCRIPTION
## What

Add a `repo` subcommand that prints the current repository name in `host/owner/repo` form:

```console
$ git-open repo
github.com/zhaochunqi/git-open
```

## Changes

- `cmd/repo.go`: new `repo` subcommand
- `cmd/git.go`: extract shared repo/remote/web-URL resolution into `resolveWebURL()`, used by both the root command and the new subcommand
- `cmd/repo_test.go`: tests covering https/ssh/gitlab remote formats and invalid remote URL error handling
- `README.md`: document the new command

## Verification

- `go build` / `go vet` / `go test ./...` all pass
- Manually verified `git-open repo` and `git-open -p` output